### PR TITLE
Feat/release channel

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@
     {
       "name": "pre-release",
       "channel": "next",
-      "prerelease": true
+      "prerelease": "${name.replace(/^pre-release/g, \"\")}"
     }
   ],
   "plugins": [

--- a/.releaserc
+++ b/.releaserc
@@ -15,7 +15,11 @@
     [
       "@semantic-release/release-notes-generator",
       {
+        "preset": "conventionalcommits",
         "header": "Super Duper CI changes",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        },
         "presetConfig": {
           "types": [
             {

--- a/.releaserc
+++ b/.releaserc
@@ -12,7 +12,75 @@
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "header": "Super Duper CI changes",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": "🚀 Features",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "🐛 Bug Fixes",
+              "hidden": false
+            },
+            {
+              "type": "docs",
+              "section": "📖 Docs",
+              "hidden": false
+            },
+            {
+              "type": "style",
+              "section": "🎨 Styles",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
+              "section": "🔩 Refactor",
+              "hidden": false
+            },
+            {
+              "type": "perf",
+              "section": "⚡️ Performances",
+              "hidden": false
+            },
+            {
+              "type": "test",
+              "section": "✅ Tests",
+              "hidden": false
+            },
+            {
+              "type": "ci",
+              "section": "🔁 CI",
+              "hidden": false
+            },
+            {
+              "type": "chore",
+              "section": "🧹 Chore",
+              "hidden": false
+            }
+          ]
+        },
+        "writerOpts": {
+          "groupBy": "type",
+          "commitGroupsSort": [
+            "feat",
+            "fix",
+            "docs",
+            "style",
+            "refactor",
+            "perf",
+            "test",
+            "ci",
+            "chore"
+          ]
+        }
+      }
+    ],
     [
       "@semantic-release/changelog",
       {

--- a/.releaserc
+++ b/.releaserc
@@ -87,7 +87,12 @@
         "changelogFile": "docs/CHANGELOG.md"
       }
     ],
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
     [
       "@semantic-release/git",
       {

--- a/.releaserc
+++ b/.releaserc
@@ -20,12 +20,12 @@
           "types": [
             {
               "type": "feat",
-              "section": "🚀 Features",
+              "section": "🚀 New Features",
               "hidden": false
             },
             {
               "type": "fix",
-              "section": "🐛 Bug Fixes",
+              "section": "🐛 Enhancements and Bug Fixes",
               "hidden": false
             },
             {

--- a/.releaserc
+++ b/.releaserc
@@ -18,10 +18,19 @@
         "preset": "conventionalcommits",
         "header": "Super Duper CI changes",
         "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
         },
         "presetConfig": {
           "types": [
+            {
+              "type": "breaking",
+              "section": "❗ Breaking Changes",
+              "hidden": false
+            },
             {
               "type": "feat",
               "section": "🚀 New Features",
@@ -72,6 +81,7 @@
         "writerOpts": {
           "groupBy": "type",
           "commitGroupsSort": [
+            "breaking",
             "feat",
             "fix",
             "docs",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.4.1](https://github.com/amtins/super-duper-ci/compare/v2.4.0...v2.4.1) (2023-04-05)
+
+
+### 🐛 Enhancements and Bug Fixes
+
+* **semantic-release:** modify default preset and parser options ([886a2ca](https://github.com/amtins/super-duper-ci/commit/886a2cade69b3001b6664a92182aed9ce02fa935))
+* **semantic-release:** modify release note section ([d28dc56](https://github.com/amtins/super-duper-ci/commit/d28dc56d9caa0026048ca4cc8cb1ea933388763e))
+
 # [2.4.0](https://github.com/amtins/super-duper-ci/compare/v2.3.0...v2.4.0) (2023-04-04)
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.4.0](https://github.com/amtins/super-duper-ci/compare/v2.3.0...v2.4.0) (2023-04-04)
+
+
+### Features
+
+* **semantic-release:** set npm publish to false ([d59bf2b](https://github.com/amtins/super-duper-ci/commit/d59bf2bb07da3f9676d3553c90c2c6ab7613baa3))
+
 # [2.3.0](https://github.com/amtins/super-duper-ci/compare/v2.2.1...v2.3.0) (2023-04-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amtins/super-duper-ci",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/amtins/super-duper-ci.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amtins/super-duper-ci",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/amtins/super-duper-ci.git"


### PR DESCRIPTION
## Description
This modification should remove the "pre-release" from the pre-released version like:
` v2.4.0-pre-release.1 -> v2.4.0-1`
    
Also adds a breaking change section to the release note


